### PR TITLE
Added support for pylibmc compression à la jbalogh/django-pylibmc.

### DIFF
--- a/newcache.py
+++ b/newcache.py
@@ -36,6 +36,10 @@ CACHE_BEHAVIORS = getattr(settings, 'CACHE_BEHAVIORS', {'hash': 'crc'})
 CACHE_KEY_MODULE = getattr(settings, 'CACHE_KEY_MODULE', 'newcache')
 CACHE_HERD_TIMEOUT = getattr(settings, 'CACHE_HERD_TIMEOUT', 60)
 
+MIN_COMPRESS = getattr(settings, 'PYLIBMC_MIN_COMPRESS_LEN', 0)  # Disabled
+if MIN_COMPRESS > 0 and not pylibmc.support_compression:
+    MIN_COMPRESS = 0
+
 class Marker(object):
     pass
 
@@ -130,7 +134,7 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.add(key_func(key), packed, real_timeout)
+        return self._cache.add(key_func(key), packed, real_timeout, MIN_COMPRESSION)
 
     def get(self, key, default=None):
         encoded_key = key_func(key)
@@ -160,7 +164,7 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.set(key_func(key), packed, real_timeout)
+        return self._cache.set(key_func(key), packed, real_timeout, MIN_COMPRESSINO)
 
     def delete(self, key):
         self._cache.delete(key_func(key))

--- a/newcache.py
+++ b/newcache.py
@@ -134,7 +134,10 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.add(key_func(key), packed, real_timeout, CACHE_MIN_COMPRESS)
+        args = [key_func(key), packed, real_timeout]
+        if using_pylibmc is True:
+            args.append(CACHE_MIN_COMPRESS)
+        return self._cache.add(*args)
 
     def get(self, key, default=None):
         encoded_key = key_func(key)
@@ -164,7 +167,10 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.set(key_func(key), packed, real_timeout, CACHE_MIN_COMPRESS)
+        args = [key_func(key), packed, real_timeout]
+        if using_pylibmc is True:
+            args.append(CACHE_MIN_COMPRESS)
+        return self._cache.set(*args)
 
     def delete(self, key):
         self._cache.delete(key_func(key))

--- a/newcache.py
+++ b/newcache.py
@@ -36,9 +36,9 @@ CACHE_BEHAVIORS = getattr(settings, 'CACHE_BEHAVIORS', {'hash': 'crc'})
 CACHE_KEY_MODULE = getattr(settings, 'CACHE_KEY_MODULE', 'newcache')
 CACHE_HERD_TIMEOUT = getattr(settings, 'CACHE_HERD_TIMEOUT', 60)
 
-MIN_COMPRESS = getattr(settings, 'PYLIBMC_MIN_COMPRESS_LEN', 0)  # Disabled
-if MIN_COMPRESS > 0 and not pylibmc.support_compression:
-    MIN_COMPRESS = 0
+CACHE_MIN_COMPRESS = getattr(settings, 'PYLIBMC_MIN_COMPRESS_LEN', 0)  # Disabled
+if CACHE_MIN_COMPRESS > 0 and not pylibmc.support_compression:
+    CACHE_MIN_COMPRESS = 0
 
 class Marker(object):
     pass
@@ -134,7 +134,7 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.add(key_func(key), packed, real_timeout, MIN_COMPRESSION)
+        return self._cache.add(key_func(key), packed, real_timeout, CACHE_MIN_COMPRESS)
 
     def get(self, key, default=None):
         encoded_key = key_func(key)
@@ -164,7 +164,7 @@ class CacheClass(BaseCache):
         else:
             packed = value
             real_timeout = self._get_memcache_timeout(timeout)
-        return self._cache.set(key_func(key), packed, real_timeout, MIN_COMPRESSINO)
+        return self._cache.set(key_func(key), packed, real_timeout, CACHE_MIN_COMPRESS)
 
     def delete(self, key):
         self._cache.delete(key_func(key))

--- a/newcache.py
+++ b/newcache.py
@@ -37,7 +37,7 @@ CACHE_KEY_MODULE = getattr(settings, 'CACHE_KEY_MODULE', 'newcache')
 CACHE_HERD_TIMEOUT = getattr(settings, 'CACHE_HERD_TIMEOUT', 60)
 
 CACHE_MIN_COMPRESS = getattr(settings, 'PYLIBMC_MIN_COMPRESS_LEN', 0)  # Disabled
-if CACHE_MIN_COMPRESS > 0 and not pylibmc.support_compression:
+if CACHE_MIN_COMPRESS > 0 and not memcache.support_compression:
     CACHE_MIN_COMPRESS = 0
 
 class Marker(object):


### PR DESCRIPTION
pylibmc supports compression via zlib. These changes allow you to optionally enable that by setting PYLIBMC_MIN_COMPRESS_LEN to any value greater than 0 in your settings.py (0 is the default and disables compression).
